### PR TITLE
Fix a move error when the path was too long

### DIFF
--- a/app/File.php
+++ b/app/File.php
@@ -55,6 +55,10 @@ class File {
      * @return boolean
      */
     public function rename_file(string $destinationDir, string $name) {
+        // Squash the directory if the filepath is too long and will generate an error
+        while (strlen($this->path) > 260) {
+            rename(dirname($this->path), dirname(dirname($this->path)) . '\\t');
+        }
         return rename($this->path, $destinationDir . '\\' . $name . '.mp3');
     }
 


### PR DESCRIPTION
Windows can not move files when the path is longer than 260 characters.
This fixes it by giving shorter names to the directories containing the file
